### PR TITLE
Update ShopifyServiceProvider.php

### DIFF
--- a/src/Integrations/Laravel/ShopifyServiceProvider.php
+++ b/src/Integrations/Laravel/ShopifyServiceProvider.php
@@ -18,7 +18,7 @@ class ShopifyServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->publishes([
-            __DIR__ . '/../config/shopify.php' => config_path('shopify.php'),
+            __DIR__ . '/../../../config/shopify.php' => config_path('shopify.php'),
         ]);
     }
 


### PR DESCRIPTION
"php artisan vendor:publish" results in "Can't locate path: </web/project-name/vendor/dan/shopify/src/Integrations/Laravel/../config/shopify.php>". This change appears to resolve this and results in a successful "Publishing complete." as a result of running the vendor:publish command.