### PR TITLE
Fix composer package name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ An object-oriented approach towards using the Shopify API.
 
 ## Composer
 
-    $ composer require dan/shopify-api v2.*
+    $ composer require dan/shopify v2.*
 
 ### Metafields!
 


### PR DESCRIPTION
When the package was migrated from `dan/shopify-api` to `dan/shopify`, the installation section of the readme was not updated. This is leading to issues like #18. This PR simply corrects the `composer require` command in readme.

Fixes #18