### PR TITLE
Add GraphQL config

### DIFF
--- a/config/shopify.php
+++ b/config/shopify.php
@@ -113,4 +113,26 @@ return [
             'themes/update'              => Dan\Shopify\Integrations\Laravel\Events\WebhookEvent::class,
         ],
     ],
+
+    'endpoints' => [
+        'assets'                        => (int) env('SHOPIFY_ENDPOINT_ASSETS_USE_GRAPHQL', 0),
+        'assigned_fulfillment_orders'   => (int) env('SHOPIFY_ENDPOINT_ASSIGNED_FULFILLMENT_ORDERS_USE_GRAPHQL', 0),
+        'customers'                     => (int) env('SHOPIFY_ENDPOINT_CUSTOMERS_USE_GRAPHQL', 0),
+        'discount_codes'                => (int) env('SHOPIFY_ENDPOINT_DISCOUNT_CODES_USE_GRAPHQL', 0),
+        'disputes'                      => (int) env('SHOPIFY_ENDPOINT_DISPUTES_USE_GRAPHQL', 0),
+        'fulfillments'                  => (int) env('SHOPIFY_ENDPOINT_FULFILLMENTS_USE_GRAPHQL', 0),
+        'fulfillment_orders'            => (int) env('SHOPIFY_ENDPOINT_FULFILLMENT_ORDERS_USE_GRAPHQL', 0),
+        'fulfillment_services'          => (int) env('SHOPIFY_ENDPOINT_FULFILLMENT_SERVICES_USE_GRAPHQL', 0),
+        'images'                        => (int) env('SHOPIFY_ENDPOINT_IMAGES_USE_GRAPHQL', 0),
+        'metafields'                    => (int) env('SHOPIFY_ENDPOINT_METAFIELDS_USE_GRAPHQL', 0),
+        'orders'                        => (int) env('SHOPIFY_ENDPOINT_ORDERS_USE_GRAPHQL', 0),
+        'price_rules'                   => (int) env('SHOPIFY_ENDPOINT_PRICE_RULES_USE_GRAPHQL', 0),
+        'products'                      => (int) env('SHOPIFY_ENDPOINT_PRODUCTS_USE_GRAPHQL', 0),
+        'recurring_application_charges' => (int) env('SHOPIFY_ENDPOINT_RECURRING_APPLICATION_CHARGES_USE_GRAPHQL', 0),
+        'risks'                         => (int) env('SHOPIFY_ENDPOINT_RISKS_USE_GRAPHQL', 0),
+        'smart_collections'             => (int) env('SHOPIFY_ENDPOINT_SMART_COLLECTIONS_USE_GRAPHQL', 0),
+        'themes'                        => (int) env('SHOPIFY_ENDPOINT_THEMES_USE_GRAPHQL', 0),
+        'variants'                      => (int) env('SHOPIFY_ENDPOINT_VARIANTS_USE_GRAPHQL', 0),
+        'webhooks'                      => (int) env('SHOPIFY_ENDPOINT_WEBHOOKS_USE_GRAPHQL', 0),
+    ]
 ];

--- a/src/Exceptions/GraphQLEnabledWithMissingQueriesException.php
+++ b/src/Exceptions/GraphQLEnabledWithMissingQueriesException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Dan\Shopify\Exceptions;
+
+use Exception;
+
+/**
+ * Class GraphQLEnabledWithMissingQueriesException.
+ */
+class GraphQLEnabledWithMissingQueriesException extends Exception
+{
+}

--- a/src/Exceptions/GraphQLEnabledWithMissingQueriesException.php
+++ b/src/Exceptions/GraphQLEnabledWithMissingQueriesException.php
@@ -9,4 +9,8 @@ use Exception;
  */
 class GraphQLEnabledWithMissingQueriesException extends Exception
 {
+     public function __construct($message = 'GraphQL is enabled for this endpoint but is currently not supported in this version.', $code = 0, Exception $previous = null)
+     {
+         parent::__construct($message, $code, $previous);
+     }
 }

--- a/src/Helpers/Assets.php
+++ b/src/Helpers/Assets.php
@@ -13,11 +13,11 @@ use Dan\Shopify\Models\Asset;
 class Assets extends Endpoint
 {
     public function ensureGraphQLSupport(): void
-	{
-		if (config('shopify.endpoints.assets')) {
+    {
+        if (config('shopify.endpoints.assets')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
         }
-	}
+    }
 
     /**
      * Get data using the `assets` endpoint.

--- a/src/Helpers/Assets.php
+++ b/src/Helpers/Assets.php
@@ -3,6 +3,7 @@
 namespace Dan\Shopify\Helpers;
 
 use BadMethodCallException;
+use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
 use Dan\Shopify\Models\AbstractModel;
 use Dan\Shopify\Models\Asset;
 
@@ -11,6 +12,13 @@ use Dan\Shopify\Models\Asset;
  */
 class Assets extends Endpoint
 {
+    protected function ensureGraphQLSupport(): void
+	{
+		if (config('shopify.endpoints.assets')) {
+            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+        }
+	}
+
     /**
      * Get data using the `assets` endpoint.
      *

--- a/src/Helpers/Assets.php
+++ b/src/Helpers/Assets.php
@@ -12,7 +12,7 @@ use Dan\Shopify\Models\Asset;
  */
 class Assets extends Endpoint
 {
-    protected function ensureGraphQLSupport(): void
+    public function ensureGraphQLSupport(): void
 	{
 		if (config('shopify.endpoints.assets')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);

--- a/src/Helpers/Assets.php
+++ b/src/Helpers/Assets.php
@@ -15,7 +15,7 @@ class Assets extends Endpoint
     public function ensureGraphQLSupport(): void
     {
         if (config('shopify.endpoints.assets')) {
-            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+            throw new GraphQLEnabledWithMissingQueriesException();
         }
     }
 

--- a/src/Helpers/AssignedFulfillmentOrders.php
+++ b/src/Helpers/AssignedFulfillmentOrders.php
@@ -7,9 +7,9 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
 class AssignedFulfillmentOrders extends Endpoint
 {
     public function ensureGraphQLSupport(): void
-	{
-		if (config('shopify.endpoints.assigned_fulfillment_orders')) {
+    {
+        if (config('shopify.endpoints.assigned_fulfillment_orders')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
         }
-	}
+    }
 }

--- a/src/Helpers/AssignedFulfillmentOrders.php
+++ b/src/Helpers/AssignedFulfillmentOrders.php
@@ -2,7 +2,14 @@
 
 namespace Dan\Shopify\Helpers;
 
+use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
+
 class AssignedFulfillmentOrders extends Endpoint
 {
-    //
+    protected function ensureGraphQLSupport(): void
+	{
+		if (config('shopify.endpoints.assigned_fulfillment_orders')) {
+            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+        }
+	}
 }

--- a/src/Helpers/AssignedFulfillmentOrders.php
+++ b/src/Helpers/AssignedFulfillmentOrders.php
@@ -6,7 +6,7 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
 
 class AssignedFulfillmentOrders extends Endpoint
 {
-    protected function ensureGraphQLSupport(): void
+    public function ensureGraphQLSupport(): void
 	{
 		if (config('shopify.endpoints.assigned_fulfillment_orders')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);

--- a/src/Helpers/AssignedFulfillmentOrders.php
+++ b/src/Helpers/AssignedFulfillmentOrders.php
@@ -9,7 +9,7 @@ class AssignedFulfillmentOrders extends Endpoint
     public function ensureGraphQLSupport(): void
     {
         if (config('shopify.endpoints.assigned_fulfillment_orders')) {
-            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+            throw new GraphQLEnabledWithMissingQueriesException();
         }
     }
 }

--- a/src/Helpers/Customers.php
+++ b/src/Helpers/Customers.php
@@ -2,6 +2,7 @@
 
 namespace Dan\Shopify\Helpers;
 
+use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
 use Dan\Shopify\Exceptions\InvalidOrMissingEndpointException;
 
 /**
@@ -9,6 +10,13 @@ use Dan\Shopify\Exceptions\InvalidOrMissingEndpointException;
  */
 class Customers extends Endpoint
 {
+    protected function ensureGraphQLSupport(): void
+	{
+		if (config('shopify.endpoints.customers')) {
+            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+        }
+	}
+
     /**
      * @param string $endpoint
      *

--- a/src/Helpers/Customers.php
+++ b/src/Helpers/Customers.php
@@ -11,11 +11,11 @@ use Dan\Shopify\Exceptions\InvalidOrMissingEndpointException;
 class Customers extends Endpoint
 {
     public function ensureGraphQLSupport(): void
-	{
-		if (config('shopify.endpoints.customers')) {
+    {
+        if (config('shopify.endpoints.customers')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
         }
-	}
+    }
 
     /**
      * @param string $endpoint

--- a/src/Helpers/Customers.php
+++ b/src/Helpers/Customers.php
@@ -10,7 +10,7 @@ use Dan\Shopify\Exceptions\InvalidOrMissingEndpointException;
  */
 class Customers extends Endpoint
 {
-    protected function ensureGraphQLSupport(): void
+    public function ensureGraphQLSupport(): void
 	{
 		if (config('shopify.endpoints.customers')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);

--- a/src/Helpers/Customers.php
+++ b/src/Helpers/Customers.php
@@ -13,7 +13,7 @@ class Customers extends Endpoint
     public function ensureGraphQLSupport(): void
     {
         if (config('shopify.endpoints.customers')) {
-            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+            throw new GraphQLEnabledWithMissingQueriesException();
         }
     }
 

--- a/src/Helpers/DiscountCodes.php
+++ b/src/Helpers/DiscountCodes.php
@@ -2,6 +2,14 @@
 
 namespace Dan\Shopify\Helpers;
 
+use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
+
 class DiscountCodes extends Endpoint
 {
+	protected function ensureGraphQLSupport(): void
+	{
+		if (config('shopify.endpoints.discount_codes')) {
+            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+        }
+	}
 }

--- a/src/Helpers/DiscountCodes.php
+++ b/src/Helpers/DiscountCodes.php
@@ -9,7 +9,7 @@ class DiscountCodes extends Endpoint
     public function ensureGraphQLSupport(): void
     {
         if (config('shopify.endpoints.discount_codes')) {
-            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+            throw new GraphQLEnabledWithMissingQueriesException();
         }
     }
 }

--- a/src/Helpers/DiscountCodes.php
+++ b/src/Helpers/DiscountCodes.php
@@ -6,7 +6,7 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
 
 class DiscountCodes extends Endpoint
 {
-	protected function ensureGraphQLSupport(): void
+	public function ensureGraphQLSupport(): void
 	{
 		if (config('shopify.endpoints.discount_codes')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);

--- a/src/Helpers/DiscountCodes.php
+++ b/src/Helpers/DiscountCodes.php
@@ -6,10 +6,10 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
 
 class DiscountCodes extends Endpoint
 {
-	public function ensureGraphQLSupport(): void
-	{
-		if (config('shopify.endpoints.discount_codes')) {
+    public function ensureGraphQLSupport(): void
+    {
+        if (config('shopify.endpoints.discount_codes')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
         }
-	}
+    }
 }

--- a/src/Helpers/Disputes.php
+++ b/src/Helpers/Disputes.php
@@ -9,10 +9,10 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
  */
 class Disputes extends Endpoint
 {
-	public function ensureGraphQLSupport(): void
-	{
-		if (config('shopify.endpoints.disputes')) {
+    public function ensureGraphQLSupport(): void
+    {
+        if (config('shopify.endpoints.disputes')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
         }
-	}
+    }
 }

--- a/src/Helpers/Disputes.php
+++ b/src/Helpers/Disputes.php
@@ -12,7 +12,7 @@ class Disputes extends Endpoint
     public function ensureGraphQLSupport(): void
     {
         if (config('shopify.endpoints.disputes')) {
-            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+            throw new GraphQLEnabledWithMissingQueriesException();
         }
     }
 }

--- a/src/Helpers/Disputes.php
+++ b/src/Helpers/Disputes.php
@@ -2,9 +2,17 @@
 
 namespace Dan\Shopify\Helpers;
 
+use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
+
 /**
  * Class Disputes.
  */
 class Disputes extends Endpoint
 {
+	protected function ensureGraphQLSupport(): void
+	{
+		if (config('shopify.endpoints.disputes')) {
+            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+        }
+	}
 }

--- a/src/Helpers/Disputes.php
+++ b/src/Helpers/Disputes.php
@@ -9,7 +9,7 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
  */
 class Disputes extends Endpoint
 {
-	protected function ensureGraphQLSupport(): void
+	public function ensureGraphQLSupport(): void
 	{
 		if (config('shopify.endpoints.disputes')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);

--- a/src/Helpers/Endpoint.php
+++ b/src/Helpers/Endpoint.php
@@ -2,6 +2,7 @@
 
 namespace Dan\Shopify\Helpers;
 
+use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
 use Dan\Shopify\Exceptions\InvalidOrMissingEndpointException;
 use Dan\Shopify\Shopify;
 
@@ -40,6 +41,8 @@ abstract class Endpoint
 
     /** @var Shopify $client */
     protected $client;
+
+    public const GRAPHQL_NOT_SUPPORTED_YET_ERROR = 'GraphQL is enabled for this endpoint but is currently not supported in this version.';
 
     /**
      * Endpoint constructor.
@@ -107,5 +110,16 @@ abstract class Endpoint
         }
 
         return $this->client->$method(...$parameters);
+    }
+
+    /**
+     * All classes that extends Endpoint is expected to override this method to decide if they currently support GraphQL
+     * They only need to support graphQL if the consumer configures GraphQL support based on config.shopify.endpoints
+     *
+     * @return bool
+     * @throws GraphQLEnabledWithMissingQueriesException
+     */
+    protected function ensureGraphQLSupport(): void
+    {
     }
 }

--- a/src/Helpers/Endpoint.php
+++ b/src/Helpers/Endpoint.php
@@ -42,8 +42,6 @@ abstract class Endpoint
     /** @var Shopify $client */
     protected $client;
 
-    public const GRAPHQL_NOT_SUPPORTED_YET_ERROR = 'GraphQL is enabled for this endpoint but is currently not supported in this version.';
-
     /**
      * Endpoint constructor.
      *

--- a/src/Helpers/Endpoint.php
+++ b/src/Helpers/Endpoint.php
@@ -119,7 +119,7 @@ abstract class Endpoint
      * @return bool
      * @throws GraphQLEnabledWithMissingQueriesException
      */
-    protected function ensureGraphQLSupport(): void
+    public function ensureGraphQLSupport(): void
     {
     }
 }

--- a/src/Helpers/FulfillmentOrders.php
+++ b/src/Helpers/FulfillmentOrders.php
@@ -9,7 +9,7 @@ class FulfillmentOrders extends Endpoint
     public function ensureGraphQLSupport(): void
     {
         if (config('shopify.endpoints.fulfillment_orders')) {
-            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+            throw new GraphQLEnabledWithMissingQueriesException();
         }
     }
 

--- a/src/Helpers/FulfillmentOrders.php
+++ b/src/Helpers/FulfillmentOrders.php
@@ -7,11 +7,11 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
 class FulfillmentOrders extends Endpoint
 {
     public function ensureGraphQLSupport(): void
-	{
-		if (config('shopify.endpoints.fulfillment_orders')) {
+    {
+        if (config('shopify.endpoints.fulfillment_orders')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
         }
-	}
+    }
 
     /**
      * Accept a fulfillment request.

--- a/src/Helpers/FulfillmentOrders.php
+++ b/src/Helpers/FulfillmentOrders.php
@@ -6,7 +6,7 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
 
 class FulfillmentOrders extends Endpoint
 {
-    protected function ensureGraphQLSupport(): void
+    public function ensureGraphQLSupport(): void
 	{
 		if (config('shopify.endpoints.fulfillment_orders')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);

--- a/src/Helpers/FulfillmentOrders.php
+++ b/src/Helpers/FulfillmentOrders.php
@@ -2,8 +2,17 @@
 
 namespace Dan\Shopify\Helpers;
 
+use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
+
 class FulfillmentOrders extends Endpoint
 {
+    protected function ensureGraphQLSupport(): void
+	{
+		if (config('shopify.endpoints.fulfillment_orders')) {
+            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+        }
+	}
+
     /**
      * Accept a fulfillment request.
      *

--- a/src/Helpers/FulfillmentServices.php
+++ b/src/Helpers/FulfillmentServices.php
@@ -9,10 +9,10 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
  */
 class FulfillmentServices extends Endpoint
 {
-	public function ensureGraphQLSupport(): void
-	{
-		if (config('shopify.endpoints.fulfillment_services')) {
+    public function ensureGraphQLSupport(): void
+    {
+        if (config('shopify.endpoints.fulfillment_services')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
         }
-	}
+    }
 }

--- a/src/Helpers/FulfillmentServices.php
+++ b/src/Helpers/FulfillmentServices.php
@@ -12,7 +12,7 @@ class FulfillmentServices extends Endpoint
     public function ensureGraphQLSupport(): void
     {
         if (config('shopify.endpoints.fulfillment_services')) {
-            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+            throw new GraphQLEnabledWithMissingQueriesException();
         }
     }
 }

--- a/src/Helpers/FulfillmentServices.php
+++ b/src/Helpers/FulfillmentServices.php
@@ -2,9 +2,17 @@
 
 namespace Dan\Shopify\Helpers;
 
+use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
+
 /**
  * Class FulfillmentServices.
  */
 class FulfillmentServices extends Endpoint
 {
+	protected function ensureGraphQLSupport(): void
+	{
+		if (config('shopify.endpoints.fulfillment_services')) {
+            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+        }
+	}
 }

--- a/src/Helpers/FulfillmentServices.php
+++ b/src/Helpers/FulfillmentServices.php
@@ -9,7 +9,7 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
  */
 class FulfillmentServices extends Endpoint
 {
-	protected function ensureGraphQLSupport(): void
+	public function ensureGraphQLSupport(): void
 	{
 		if (config('shopify.endpoints.fulfillment_services')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);

--- a/src/Helpers/Fulfillments.php
+++ b/src/Helpers/Fulfillments.php
@@ -12,7 +12,7 @@ class Fulfillments extends Endpoint
     public function ensureGraphQLSupport(): void
     {
         if (config('shopify.endpoints.fulfillments')) {
-            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+            throw new GraphQLEnabledWithMissingQueriesException();
         }
     }
 }

--- a/src/Helpers/Fulfillments.php
+++ b/src/Helpers/Fulfillments.php
@@ -9,10 +9,10 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
  */
 class Fulfillments extends Endpoint
 {
-	public function ensureGraphQLSupport(): void
-	{
-		if (config('shopify.endpoints.fulfillments')) {
+    public function ensureGraphQLSupport(): void
+    {
+        if (config('shopify.endpoints.fulfillments')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
         }
-	}
+    }
 }

--- a/src/Helpers/Fulfillments.php
+++ b/src/Helpers/Fulfillments.php
@@ -2,9 +2,17 @@
 
 namespace Dan\Shopify\Helpers;
 
+use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
+
 /**
  * Class Fulfillments.
  */
 class Fulfillments extends Endpoint
 {
+	protected function ensureGraphQLSupport(): void
+	{
+		if (config('shopify.endpoints.fulfillments')) {
+            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+        }
+	}
 }

--- a/src/Helpers/Fulfillments.php
+++ b/src/Helpers/Fulfillments.php
@@ -9,7 +9,7 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
  */
 class Fulfillments extends Endpoint
 {
-	protected function ensureGraphQLSupport(): void
+	public function ensureGraphQLSupport(): void
 	{
 		if (config('shopify.endpoints.fulfillments')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);

--- a/src/Helpers/Images.php
+++ b/src/Helpers/Images.php
@@ -12,7 +12,7 @@ class Images extends Endpoint
     public function ensureGraphQLSupport(): void
     {
         if (config('shopify.endpoints.images')) {
-            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+            throw new GraphQLEnabledWithMissingQueriesException();
         }
     }
 }

--- a/src/Helpers/Images.php
+++ b/src/Helpers/Images.php
@@ -9,10 +9,10 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
  */
 class Images extends Endpoint
 {
-	public function ensureGraphQLSupport(): void
-	{
-		if (config('shopify.endpoints.images')) {
+    public function ensureGraphQLSupport(): void
+    {
+        if (config('shopify.endpoints.images')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
         }
-	}
+    }
 }

--- a/src/Helpers/Images.php
+++ b/src/Helpers/Images.php
@@ -9,7 +9,7 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
  */
 class Images extends Endpoint
 {
-	protected function ensureGraphQLSupport(): void
+	public function ensureGraphQLSupport(): void
 	{
 		if (config('shopify.endpoints.images')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);

--- a/src/Helpers/Images.php
+++ b/src/Helpers/Images.php
@@ -2,9 +2,17 @@
 
 namespace Dan\Shopify\Helpers;
 
+use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
+
 /**
  * Class Images.
  */
 class Images extends Endpoint
 {
+	protected function ensureGraphQLSupport(): void
+	{
+		if (config('shopify.endpoints.images')) {
+            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+        }
+	}
 }

--- a/src/Helpers/Metafields.php
+++ b/src/Helpers/Metafields.php
@@ -7,11 +7,11 @@ use Dan\Shopify\Shopify;
 
 class Metafields extends Endpoint
 {
-	public function ensureGraphQLSupport(): void
-	{
-		if (config('shopify.endpoints.metafields')) {
+    public function ensureGraphQLSupport(): void
+    {
+        if (config('shopify.endpoints.metafields')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
         }
-	}
+    }
 
 }

--- a/src/Helpers/Metafields.php
+++ b/src/Helpers/Metafields.php
@@ -2,9 +2,16 @@
 
 namespace Dan\Shopify\Helpers;
 
+use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
 use Dan\Shopify\Shopify;
 
 class Metafields extends Endpoint
 {
+	protected function ensureGraphQLSupport(): void
+	{
+		if (config('shopify.endpoints.metafields')) {
+            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+        }
+	}
 
 }

--- a/src/Helpers/Metafields.php
+++ b/src/Helpers/Metafields.php
@@ -7,7 +7,7 @@ use Dan\Shopify\Shopify;
 
 class Metafields extends Endpoint
 {
-	protected function ensureGraphQLSupport(): void
+	public function ensureGraphQLSupport(): void
 	{
 		if (config('shopify.endpoints.metafields')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);

--- a/src/Helpers/Metafields.php
+++ b/src/Helpers/Metafields.php
@@ -10,7 +10,7 @@ class Metafields extends Endpoint
     public function ensureGraphQLSupport(): void
     {
         if (config('shopify.endpoints.metafields')) {
-            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+            throw new GraphQLEnabledWithMissingQueriesException();
         }
     }
 

--- a/src/Helpers/Orders.php
+++ b/src/Helpers/Orders.php
@@ -9,10 +9,10 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
  */
 class Orders extends Endpoint
 {
-	public function ensureGraphQLSupport(): void
-	{
-		if (config('shopify.endpoints.orders')) {
+    public function ensureGraphQLSupport(): void
+    {
+        if (config('shopify.endpoints.orders')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
         }
-	}
+    }
 }

--- a/src/Helpers/Orders.php
+++ b/src/Helpers/Orders.php
@@ -2,9 +2,17 @@
 
 namespace Dan\Shopify\Helpers;
 
+use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
+
 /**
  * Class Orders.
  */
 class Orders extends Endpoint
 {
+	protected function ensureGraphQLSupport(): void
+	{
+		if (config('shopify.endpoints.orders')) {
+            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+        }
+	}
 }

--- a/src/Helpers/Orders.php
+++ b/src/Helpers/Orders.php
@@ -9,7 +9,7 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
  */
 class Orders extends Endpoint
 {
-	protected function ensureGraphQLSupport(): void
+	public function ensureGraphQLSupport(): void
 	{
 		if (config('shopify.endpoints.orders')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);

--- a/src/Helpers/Orders.php
+++ b/src/Helpers/Orders.php
@@ -12,7 +12,7 @@ class Orders extends Endpoint
     public function ensureGraphQLSupport(): void
     {
         if (config('shopify.endpoints.orders')) {
-            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+            throw new GraphQLEnabledWithMissingQueriesException();
         }
     }
 }

--- a/src/Helpers/PriceRules.php
+++ b/src/Helpers/PriceRules.php
@@ -6,10 +6,10 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
 
 class PriceRules extends Endpoint
 {
-	public function ensureGraphQLSupport(): void
-	{
-		if (config('shopify.endpoints.price_rules')) {
+    public function ensureGraphQLSupport(): void
+    {
+        if (config('shopify.endpoints.price_rules')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
         }
-	}
+    }
 }

--- a/src/Helpers/PriceRules.php
+++ b/src/Helpers/PriceRules.php
@@ -2,4 +2,14 @@
 
 namespace Dan\Shopify\Helpers;
 
-class PriceRules extends Endpoint { }
+use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
+
+class PriceRules extends Endpoint
+{
+	protected function ensureGraphQLSupport(): void
+	{
+		if (config('shopify.endpoints.price_rules')) {
+            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+        }
+	}
+}

--- a/src/Helpers/PriceRules.php
+++ b/src/Helpers/PriceRules.php
@@ -6,7 +6,7 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
 
 class PriceRules extends Endpoint
 {
-	protected function ensureGraphQLSupport(): void
+	public function ensureGraphQLSupport(): void
 	{
 		if (config('shopify.endpoints.price_rules')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);

--- a/src/Helpers/PriceRules.php
+++ b/src/Helpers/PriceRules.php
@@ -9,7 +9,7 @@ class PriceRules extends Endpoint
     public function ensureGraphQLSupport(): void
     {
         if (config('shopify.endpoints.price_rules')) {
-            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+            throw new GraphQLEnabledWithMissingQueriesException();
         }
     }
 }

--- a/src/Helpers/Products.php
+++ b/src/Helpers/Products.php
@@ -9,10 +9,10 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
  */
 class Products extends Endpoint
 {
-	public function ensureGraphQLSupport(): void
-	{
-		if (config('shopify.endpoints.products')) {
+    public function ensureGraphQLSupport(): void
+    {
+        if (config('shopify.endpoints.products')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
         }
-	}
+    }
 }

--- a/src/Helpers/Products.php
+++ b/src/Helpers/Products.php
@@ -12,7 +12,7 @@ class Products extends Endpoint
     public function ensureGraphQLSupport(): void
     {
         if (config('shopify.endpoints.products')) {
-            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+            throw new GraphQLEnabledWithMissingQueriesException();
         }
     }
 }

--- a/src/Helpers/Products.php
+++ b/src/Helpers/Products.php
@@ -2,9 +2,17 @@
 
 namespace Dan\Shopify\Helpers;
 
+use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
+
 /**
  * Class Products.
  */
 class Products extends Endpoint
 {
+	protected function ensureGraphQLSupport(): void
+	{
+		if (config('shopify.endpoints.products')) {
+            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+        }
+	}
 }

--- a/src/Helpers/Products.php
+++ b/src/Helpers/Products.php
@@ -9,7 +9,7 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
  */
 class Products extends Endpoint
 {
-	protected function ensureGraphQLSupport(): void
+	public function ensureGraphQLSupport(): void
 	{
 		if (config('shopify.endpoints.products')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);

--- a/src/Helpers/RecurringApplicationCharges.php
+++ b/src/Helpers/RecurringApplicationCharges.php
@@ -7,9 +7,9 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
 class RecurringApplicationCharges extends Endpoint
 {
     public function ensureGraphQLSupport(): void
-	{
-		if (config('shopify.endpoints.recurring_application_charges')) {
+    {
+        if (config('shopify.endpoints.recurring_application_charges')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
         }
-	}
+    }
 }

--- a/src/Helpers/RecurringApplicationCharges.php
+++ b/src/Helpers/RecurringApplicationCharges.php
@@ -9,7 +9,7 @@ class RecurringApplicationCharges extends Endpoint
     public function ensureGraphQLSupport(): void
     {
         if (config('shopify.endpoints.recurring_application_charges')) {
-            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+            throw new GraphQLEnabledWithMissingQueriesException();
         }
     }
 }

--- a/src/Helpers/RecurringApplicationCharges.php
+++ b/src/Helpers/RecurringApplicationCharges.php
@@ -6,7 +6,7 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
 
 class RecurringApplicationCharges extends Endpoint
 {
-    protected function ensureGraphQLSupport(): void
+    public function ensureGraphQLSupport(): void
 	{
 		if (config('shopify.endpoints.recurring_application_charges')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);

--- a/src/Helpers/RecurringApplicationCharges.php
+++ b/src/Helpers/RecurringApplicationCharges.php
@@ -2,7 +2,14 @@
 
 namespace Dan\Shopify\Helpers;
 
+use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
+
 class RecurringApplicationCharges extends Endpoint
 {
-    //
+    protected function ensureGraphQLSupport(): void
+	{
+		if (config('shopify.endpoints.recurring_application_charges')) {
+            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+        }
+	}
 }

--- a/src/Helpers/Risks.php
+++ b/src/Helpers/Risks.php
@@ -9,10 +9,10 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
  */
 class Risks extends Endpoint
 {
-	public function ensureGraphQLSupport(): void
-	{
-		if (config('shopify.endpoints.risks')) {
+    public function ensureGraphQLSupport(): void
+    {
+        if (config('shopify.endpoints.risks')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
         }
-	}
+    }
 }

--- a/src/Helpers/Risks.php
+++ b/src/Helpers/Risks.php
@@ -12,7 +12,7 @@ class Risks extends Endpoint
     public function ensureGraphQLSupport(): void
     {
         if (config('shopify.endpoints.risks')) {
-            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+            throw new GraphQLEnabledWithMissingQueriesException();
         }
     }
 }

--- a/src/Helpers/Risks.php
+++ b/src/Helpers/Risks.php
@@ -9,7 +9,7 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
  */
 class Risks extends Endpoint
 {
-	protected function ensureGraphQLSupport(): void
+	public function ensureGraphQLSupport(): void
 	{
 		if (config('shopify.endpoints.risks')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);

--- a/src/Helpers/Risks.php
+++ b/src/Helpers/Risks.php
@@ -2,9 +2,17 @@
 
 namespace Dan\Shopify\Helpers;
 
+use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
+
 /**
  * Class Risks.
  */
 class Risks extends Endpoint
 {
+	protected function ensureGraphQLSupport(): void
+	{
+		if (config('shopify.endpoints.risks')) {
+            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+        }
+	}
 }

--- a/src/Helpers/SmartCollections.php
+++ b/src/Helpers/SmartCollections.php
@@ -6,7 +6,7 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
 
 class SmartCollections extends Endpoint
 {
-	protected function ensureGraphQLSupport(): void
+	public function ensureGraphQLSupport(): void
 	{
 		if (config('shopify.endpoints.smart_collections')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);

--- a/src/Helpers/SmartCollections.php
+++ b/src/Helpers/SmartCollections.php
@@ -2,6 +2,14 @@
 
 namespace Dan\Shopify\Helpers;
 
+use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
+
 class SmartCollections extends Endpoint
 {
+	protected function ensureGraphQLSupport(): void
+	{
+		if (config('shopify.endpoints.smart_collections')) {
+            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+        }
+	}
 }

--- a/src/Helpers/SmartCollections.php
+++ b/src/Helpers/SmartCollections.php
@@ -9,7 +9,7 @@ class SmartCollections extends Endpoint
     public function ensureGraphQLSupport(): void
     {
         if (config('shopify.endpoints.smart_collections')) {
-            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+            throw new GraphQLEnabledWithMissingQueriesException();
         }
     }
 }

--- a/src/Helpers/SmartCollections.php
+++ b/src/Helpers/SmartCollections.php
@@ -6,10 +6,10 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
 
 class SmartCollections extends Endpoint
 {
-	public function ensureGraphQLSupport(): void
-	{
-		if (config('shopify.endpoints.smart_collections')) {
+    public function ensureGraphQLSupport(): void
+    {
+        if (config('shopify.endpoints.smart_collections')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
         }
-	}
+    }
 }

--- a/src/Helpers/Themes.php
+++ b/src/Helpers/Themes.php
@@ -14,7 +14,7 @@ class Themes extends Endpoint
     public function ensureGraphQLSupport(): void
     {
         if (config('shopify.endpoints.themes')) {
-            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+            throw new GraphQLEnabledWithMissingQueriesException();
         }
     }
 }

--- a/src/Helpers/Themes.php
+++ b/src/Helpers/Themes.php
@@ -11,7 +11,7 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
  */
 class Themes extends Endpoint
 {
-	protected function ensureGraphQLSupport(): void
+	public function ensureGraphQLSupport(): void
 	{
 		if (config('shopify.endpoints.themes')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);

--- a/src/Helpers/Themes.php
+++ b/src/Helpers/Themes.php
@@ -11,10 +11,10 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
  */
 class Themes extends Endpoint
 {
-	public function ensureGraphQLSupport(): void
-	{
-		if (config('shopify.endpoints.themes')) {
+    public function ensureGraphQLSupport(): void
+    {
+        if (config('shopify.endpoints.themes')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
         }
-	}
+    }
 }

--- a/src/Helpers/Themes.php
+++ b/src/Helpers/Themes.php
@@ -2,6 +2,8 @@
 
 namespace Dan\Shopify\Helpers;
 
+use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
+
 /**
  * Class Themes.
  *
@@ -9,4 +11,10 @@ namespace Dan\Shopify\Helpers;
  */
 class Themes extends Endpoint
 {
+	protected function ensureGraphQLSupport(): void
+	{
+		if (config('shopify.endpoints.themes')) {
+            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+        }
+	}
 }

--- a/src/Helpers/Variants.php
+++ b/src/Helpers/Variants.php
@@ -9,10 +9,10 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
  */
 class Variants extends Endpoint
 {
-	public function ensureGraphQLSupport(): void
-	{
-		if (config('shopify.endpoints.variants')) {
+    public function ensureGraphQLSupport(): void
+    {
+        if (config('shopify.endpoints.variants')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
         }
-	}
+    }
 }

--- a/src/Helpers/Variants.php
+++ b/src/Helpers/Variants.php
@@ -12,7 +12,7 @@ class Variants extends Endpoint
     public function ensureGraphQLSupport(): void
     {
         if (config('shopify.endpoints.variants')) {
-            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+            throw new GraphQLEnabledWithMissingQueriesException();
         }
     }
 }

--- a/src/Helpers/Variants.php
+++ b/src/Helpers/Variants.php
@@ -9,7 +9,7 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
  */
 class Variants extends Endpoint
 {
-	protected function ensureGraphQLSupport(): void
+	public function ensureGraphQLSupport(): void
 	{
 		if (config('shopify.endpoints.variants')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);

--- a/src/Helpers/Variants.php
+++ b/src/Helpers/Variants.php
@@ -2,9 +2,17 @@
 
 namespace Dan\Shopify\Helpers;
 
+use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
+
 /**
  * Class Variants.
  */
 class Variants extends Endpoint
 {
+	protected function ensureGraphQLSupport(): void
+	{
+		if (config('shopify.endpoints.variants')) {
+            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+        }
+	}
 }

--- a/src/Helpers/Webhooks.php
+++ b/src/Helpers/Webhooks.php
@@ -9,7 +9,7 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
  */
 class Webhooks extends Endpoint
 {
-	protected function ensureGraphQLSupport(): void
+	public function ensureGraphQLSupport(): void
 	{
 		if (config('shopify.endpoints.webhooks')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);

--- a/src/Helpers/Webhooks.php
+++ b/src/Helpers/Webhooks.php
@@ -2,9 +2,17 @@
 
 namespace Dan\Shopify\Helpers;
 
+use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
+
 /**
  * Class Webhooks.
  */
 class Webhooks extends Endpoint
 {
+	protected function ensureGraphQLSupport(): void
+	{
+		if (config('shopify.endpoints.webhooks')) {
+            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+        }
+	}
 }

--- a/src/Helpers/Webhooks.php
+++ b/src/Helpers/Webhooks.php
@@ -12,7 +12,7 @@ class Webhooks extends Endpoint
     public function ensureGraphQLSupport(): void
     {
         if (config('shopify.endpoints.webhooks')) {
-            throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
+            throw new GraphQLEnabledWithMissingQueriesException();
         }
     }
 }

--- a/src/Helpers/Webhooks.php
+++ b/src/Helpers/Webhooks.php
@@ -9,10 +9,10 @@ use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
  */
 class Webhooks extends Endpoint
 {
-	public function ensureGraphQLSupport(): void
-	{
-		if (config('shopify.endpoints.webhooks')) {
+    public function ensureGraphQLSupport(): void
+    {
+        if (config('shopify.endpoints.webhooks')) {
             throw new GraphQLEnabledWithMissingQueriesException(self::GRAPHQL_NOT_SUPPORTED_YET_ERROR);
         }
-	}
+    }
 }

--- a/src/Shopify.php
+++ b/src/Shopify.php
@@ -856,7 +856,10 @@ class Shopify
         $className = "Dan\Shopify\\Helpers\\".Util::studly($endpoint);
 
         if (class_exists($className)) {
-            return new $className($this);
+            $classInstance = new $className($this);
+            $classInstance->ensureGraphQLSupport();
+
+            return $classInstance;
         }
 
         // If user tries to access property that doesn't exist, scold them.

--- a/tests/ShopApiTest.php
+++ b/tests/ShopApiTest.php
@@ -2,6 +2,7 @@
 
 namespace Dan\Shopify\Test;
 
+use Dan\Shopify\Exceptions\GraphQLEnabledWithMissingQueriesException;
 use Dan\Shopify\Shopify;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
@@ -28,5 +29,13 @@ class ShopApiTest extends TestCase
                 && $request->method() == 'GET'
                 && $request->hasHeader('X-Shopify-Access-Token', 'token');
         });
+    }
+
+    public function test_throws_when_graphql_is_enabled_but_endpoint_does_not_support_graphql_yet()
+    {
+        config(['shopify.endpoints.assets' => 1]);
+        $this->expectException(GraphQLEnabledWithMissingQueriesException::class);
+
+        (new Shopify('shop', 'token'))->assets->get();
     }
 }


### PR DESCRIPTION
### Description
This PR is the begining of a full QraphQL support for this package. It introduces feature flags based on `env` for consumers to toggle between rest and graphql.

Right now, no endpoint supports graphql yet, but subsequent PRs will handle 1 endpoint at a time while ensuring that the response is consistent with the current rest response.